### PR TITLE
Fix wall bug

### DIFF
--- a/Script/Goober.gd
+++ b/Script/Goober.gd
@@ -16,19 +16,21 @@ func _ready():
 		NodeSprite.flip_h = true
 
 func _physics_process(delta):
-	var cast = NodeCast.is_colliding()
-	
-	if cast == false:
+	# If there's no ground, rotate
+	if NodeCast.is_colliding() == false:
 		velocity.x = -velocity.x
 		NodeSprite.flip_h = !NodeSprite.flip_h
-	
+
+
+	# If there's a wall, rotate
+	if is_on_wall():
+		if(NodeSprite.flip_h):
+			velocity.x = spd
+		else:
+			velocity.x = -spd
+		NodeSprite.flip_h = !NodeSprite.flip_h
+
 	move_and_slide()
-	
-	# if stuck on wall, change direction
-	var mov = velocity
-	if mov.x == 0:
-		velocity.x = -velocity.x
-		NodeSprite.flip_h = !NodeSprite.flip_h
 	wrapObject()
 
 	

--- a/test/resources/TestIntegrationScene.tscn
+++ b/test/resources/TestIntegrationScene.tscn
@@ -1,14 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://b11pvvfudux0h"]
+[gd_scene load_steps=4 format=3 uid="uid://b11pvvfudux0h"]
 
 [ext_resource type="TileSet" uid="uid://dr4c3d1ltjg3x" path="res://TileMap/TileSet.tres" id="1"]
 [ext_resource type="PackedScene" uid="uid://clj7q4l2l3cpc" path="res://Scene/Player.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://bjpnsgbf34yfq" path="res://Scene/Goober.tscn" id="3_6suda"]
 
 [node name="TestIntegrationLevel2" type="Node"]
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = ExtResource("1")
 format = 2
-layer_0/tile_data = PackedInt32Array(720896, 0, 0, 720897, 0, 0, 720898, 0, 0, 720899, 0, 0, 720900, 0, 0, 720901, 0, 0, 720902, 0, 0, 720903, 0, 0, 720904, 0, 0, 720905, 0, 0, 720906, 0, 0, 720907, 0, 0, 720908, 0, 0, 720909, 0, 0, 720910, 0, 0, 720911, 0, 0, 720912, 0, 0, 720913, 0, 0)
+layer_0/tile_data = PackedInt32Array(720896, 0, 0, 720897, 0, 0, 720898, 0, 0, 720899, 0, 0, 720900, 0, 0, 720901, 0, 0, 720902, 0, 0, 720903, 0, 0, 720904, 0, 0, 720905, 0, 0, 720906, 0, 0, 720907, 0, 0, 720908, 0, 0, 720909, 0, 0, 720910, 0, 0, 720911, 0, 0, 655370, 0, 0)
 
 [node name="Player" parent="." instance=ExtResource("3")]
 position = Vector2(70, 86)
+
+[node name="Goober" parent="." instance=ExtResource("3_6suda")]
+position = Vector2(118, 85)


### PR DESCRIPTION
In the conversion to Godot 4 we broke the functionality of rotating the goober when he reaches a wall.

This fixes it by using the Godot functionality of is_on_wall() and depending on how the sprite is turned, adding the inverse default velocity (since it's zero once it reaches the wall).

Also changed the code for checking if the floor is present for simplicity.

The change in the TestIntegrationScene is there so I could test the behavior in scene instead of having to load the entire game (should probably make unit tests for Goober).